### PR TITLE
Wire interface can now be changed and improved begin function

### DIFF
--- a/examples/TCA6416A_test/TCA6416A_test.ino
+++ b/examples/TCA6416A_test/TCA6416A_test.ino
@@ -3,7 +3,13 @@
 TCA6416A pins;
 
 void setup() {
-	pins.begin(0); // Address 0 or 1, depending on your addr-pin
+	Serial.begin(115200);
+	while (!Serial);
+
+	while (!pins.begin(0)) { // Address 0 or 1, depending on your addr-pin
+    	Serial.println("TCA6416A not found");
+		delay(1000);
+	}
 
 	pins.pin_mode(0, OUTPUT);
 	pins.pin_mode(1, INPUT);

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library for operating TCA6416A.
 paragraph=Arduino library for operating TCA6416A.
 category=Communication
 url=https://github.com/haakonnessjoen/TCA6416A
-architectures=avr
+architectures=*

--- a/src/TCA6416A.cpp
+++ b/src/TCA6416A.cpp
@@ -4,12 +4,21 @@
 #include "TCA6416A.h"
 
 // NB!: Only address 0 or 1
-void TCA6416A::begin(uint8_t address) {
-	i2caddr = 0x20 | address;
-	TW.begin();
+bool TCA6416A::begin(uint8_t addr_pin, TwoWire *theWire) {
+	i2caddr = 0x20 | addr_pin;
+	TW = theWire;
+	TW->begin();
+
+	/// Check if device is connected
+	TW->beginTransmission((int)i2caddr);
+	if (TW->endTransmission() != 0) {
+		return false;
+	}
 
 	port_read();
 	mode_read();
+
+	return true;
 }
 
 void TCA6416A::pin_write(uint8_t pinNum, uint8_t level) {
@@ -49,51 +58,51 @@ int TCA6416A::pin_read(uint8_t pinNum) {
 }
 
 void TCA6416A::port_write(uint16_t i2cportval) {
-	TW.beginTransmission((int)i2caddr);
-	TW.write(TCAREG_OUTPUT0);
+	TW->beginTransmission((int)i2caddr);
+	TW->write(TCAREG_OUTPUT0);
 
-	TW.write(i2cportval & 0x00FF);
-	TW.write(i2cportval >> 8 );
+	TW->write(i2cportval & 0x00FF);
+	TW->write(i2cportval >> 8 );
 
-	TW.endTransmission();
+	TW->endTransmission();
 
 	pinState = i2cportval;
 }
 
 uint16_t TCA6416A::port_read() {
-	TW.beginTransmission((int)i2caddr);
-	TW.write(TCAREG_INPUT0);
-	TW.endTransmission();
+	TW->beginTransmission((int)i2caddr);
+	TW->write(TCAREG_INPUT0);
+	TW->endTransmission();
 
-	TW.requestFrom((int)i2caddr, (int)i2cwidth);
+	TW->requestFrom((int)i2caddr, (int)i2cwidth);
 
-	pinState = TW.read();
-	pinState |= TW.read() << 8;
+	pinState = TW->read();
+	pinState |= TW->read() << 8;
 
 	return pinState;
 }
 
 void TCA6416A::mode_write(uint16_t modes) {
-	TW.beginTransmission((int)i2caddr);
-	TW.write(TCAREG_CONFIG0);
+	TW->beginTransmission((int)i2caddr);
+	TW->write(TCAREG_CONFIG0);
 
-	TW.write(modes & 0x00FF);
-	TW.write(modes >> 8 );
+	TW->write(modes & 0x00FF);
+	TW->write(modes >> 8 );
 
-	TW.endTransmission();
+	TW->endTransmission();
 
 	pinModes = modes;
 }
 
 uint16_t TCA6416A::mode_read() {
-	TW.beginTransmission((int)i2caddr);
-	TW.write(TCAREG_CONFIG0);
-	TW.endTransmission();
+	TW->beginTransmission((int)i2caddr);
+	TW->write(TCAREG_CONFIG0);
+	TW->endTransmission();
 
-	TW.requestFrom((int)i2caddr, (int)i2cwidth);
+	TW->requestFrom((int)i2caddr, (int)i2cwidth);
 
-	pinModes = TW.read();
-	pinModes |= TW.read() << 8;
+	pinModes = TW->read();
+	pinModes |= TW->read() << 8;
 
 	return pinModes;
 }

--- a/src/TCA6416A.h
+++ b/src/TCA6416A.h
@@ -23,7 +23,7 @@
 
 class TCA6416A {
 public:
-	void begin(uint8_t address);
+	bool begin(uint8_t addr_pin, TwoWire *theWire = &Wire);
 	void pin_mode(uint8_t pinNum, int mode);
 	void pin_write(uint8_t pinNum, uint8_t level);
 	int  pin_read(uint8_t pinNum);
@@ -33,11 +33,11 @@ public:
 	uint16_t mode_read();
 
 private:
-		TwoWire TW;
-    uint8_t i2caddr;
-    uint8_t i2cwidth;
-		uint16_t pinState;
-		uint16_t pinModes;
+	TwoWire *TW;
+	uint8_t i2caddr;
+	uint8_t i2cwidth;
+	uint16_t pinState;
+	uint16_t pinModes;
 };
 
 #endif // TCA6416A_H


### PR DESCRIPTION
Constructor now includes an argument for the Wire interface to be used. It defaults to `Wire` if omitted, so any existing code will not break.

Added a boolean return to the begin function so you can see if the target IC was connected to or not.

Changed architecture to wildcard as no platform specific code is used. 