### PR TITLE
[Bug] Error: i2c_master_receive(1258): i2c receive buffer or size invalid

### DIFF
--- a/src/TCA6416A.cpp
+++ b/src/TCA6416A.cpp
@@ -6,6 +6,7 @@
 // NB!: Only address 0 or 1
 bool TCA6416A::begin(uint8_t addr_bit, TwoWire *theWire) {
 	i2caddr = 0x20 | addr_bit;
+	i2cwidth = 2;
 	TW = theWire;
 	TW->begin();
 


### PR DESCRIPTION
We need to specify the buffer size to the Wire library

TCAL6416 is a 16 bit device, we need to read 2 bytes.
The local variable exist, but it is not set.
I can parametrize it as well, but looking at different 6416 they all seem to use 2 bytes.

